### PR TITLE
Fix find pane highlighted text (resolve #20)

### DIFF
--- a/styles/overrides.less
+++ b/styles/overrides.less
@@ -111,6 +111,15 @@
   color: @nova_normal_black;
 }
 
+atom-text-editor[mini] {
+  &::shadow {
+    .selection .region {
+      background-color: @nova_decoration_dark;
+      margin-top: 2px;
+    }
+  }
+}
+
 // PANELS
 .package-card {
   background: @nova_normal_black !important;


### PR DESCRIPTION
Default was transparent. I picked the dark decoration as light was too low contrast. Also added a margin to prevent it touching the top border of the field and being quite far from the bottom.

Let me know if you're not keen on the section of the file I added it to or the nesting - kept any one line from getting too long but I can change if you have a preference.

Cheers 👌 