### PR TITLE
Restore selected highlight to modified tree items (resolve #19)

### DIFF
--- a/styles/overrides.less
+++ b/styles/overrides.less
@@ -41,7 +41,9 @@
   .status-added,
   .status-modified {
     padding-left: 15px !important;
-    color: inherit;
+    &:not(.selected) {
+      color: inherit;
+    }
   }
   .status-added {
     border-left: 2px solid @syntax-color-added;


### PR DESCRIPTION
Don't override text color to `inherit` for currently selected items.

Alternatively could add `.selected { color: ... }` below?