### PR TITLE
update for Atom v1.13

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -16,7 +16,6 @@ atom-text-editor[mini] {
     background-color: darken(@input-background-color, 5%);
   }
 
-  &, // <-- Deprecated. The `&,` can be removed once the Shadow DOM can't be turned off in the settings.
   &.editor {
     .placeholder-text {
       color: @text-color-subtle;

--- a/styles/editor.less
+++ b/styles/editor.less
@@ -17,7 +17,7 @@ atom-text-editor[mini] {
   }
 
   &, // <-- Deprecated. The `&,` can be removed once the Shadow DOM can't be turned off in the settings.
-  &::shadow {
+  &.editor {
     .placeholder-text {
       color: @text-color-subtle;
     }

--- a/styles/overrides.less
+++ b/styles/overrides.less
@@ -188,7 +188,7 @@
 }
 
 atom-text-editor[mini] {
-  &::shadow {
+  &.editor {
     .selection .region {
       background-color: @nova_decoration_dark;
       margin-top: 2px;


### PR DESCRIPTION
As per deprecation cop's directions I - switched ::shadow to .editor, and removed the deprecated &,

No deprecation warning after these changes, and all styling remains the same. 

Cheers.